### PR TITLE
hopefully fixed app deploy failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,11 +38,14 @@ jobs:
     - name: Publish application
       run: dotnet publish ./src/dotnet/AzureDeploymentWeb/AzureDeploymentWeb.csproj --configuration Release --output ./publish --no-build
       
+    - name: Create deployment package
+      run: zip -r ./publish.zip ./publish
+      
     - name: Upload build artifact
       uses: actions/upload-artifact@v4
       with:
         name: webapp-build
-        path: ./publish
+        path: ./publish.zip
         retention-days: 1
 
   deploy:
@@ -82,5 +85,5 @@ jobs:
       uses: azure/webapps-deploy@v3
       with:
         app-name: ${{ steps.bicep-deploy.outputs.webAppName }}
-        package: ./publish
+        package: ./publish.zip
         type: 'ZIP'


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy.yml` to streamline the deployment process by creating a zip package for the application build and using it consistently throughout the workflow.

Deployment workflow updates:

* Added a step to create a deployment package by zipping the `./publish` directory (`Create deployment package`) and updated the artifact upload step to use the zip file instead of the directory. (`jobs.publish` section)
* Modified the deployment step to use the zipped package (`./publish.zip`) for deploying the application instead of the unzipped directory. (`jobs.deploy` section)