### PR TITLE
more workflow fixing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
       run: dotnet publish ./src/dotnet/AzureDeploymentWeb/AzureDeploymentWeb.csproj --configuration Release --output ./publish --no-build
       
     - name: Create deployment package
-      run: zip -r ./publish.zip ./publish
+      run: cd publish && zip -r ../publish.zip .
       
     - name: Upload build artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request includes an adjustment to the deployment workflow in `.github/workflows/deploy.yml`. The change modifies how the deployment package is created to ensure the `zip` command operates within the `publish` directory.

Deployment workflow adjustment:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L42-R42): Updated the `Create deployment package` step to change the working directory to `publish` before zipping its contents, ensuring the relative paths in the archive are correct.