### PR TITLE
Once more...

### DIFF
--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const isRemote = process.env.BASE_URL && !process.env.BASE_URL.startsWith('http://localhost');
+
 /**
  * @see https://playwright.dev/docs/test-configuration
  */
@@ -65,11 +67,12 @@ export default defineConfig({
     // },
   ],
 
-  /* Run your local dev server before starting the tests */
-  webServer: {
-    command: 'dotnet run --project ../../src/dotnet/AzureDeploymentWeb',
-    url: 'http://localhost:5000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
-  },
+  // Only use webServer when running locally
+  ...(isRemote ? {} : {
+    webServer: {
+      command: 'dotnet run --project ../src/dotnet/AzureDeploymentWeb',
+      url: 'http://localhost:5000',
+      reuseExistingServer: !process.env.CI,
+    }
+  })
 });


### PR DESCRIPTION
This pull request updates the Playwright test configuration to better handle remote and local environments. The changes introduce a conditional setup for the `webServer` configuration based on whether the tests are running locally or remotely.

### Environment-aware configuration:

* [`tests/playwright/playwright.config.ts`](diffhunk://#diff-0ecef19bca265d5ad064b4c2685b86ca2fced2a005f66e3e529c2b6df91fec9cR3-R4): Added a new constant `isRemote` to detect if the tests are running against a remote environment based on the `BASE_URL` environment variable.
* [`tests/playwright/playwright.config.ts`](diffhunk://#diff-0ecef19bca265d5ad064b4c2685b86ca2fced2a005f66e3e529c2b6df91fec9cL68-R77): Modified the `webServer` configuration to only initialize when running locally, ensuring compatibility with remote environments.