### PR TITLE
Updated view.  again

### DIFF
--- a/src/dotnet/AzureDeploymentWeb/Views/Deployment/Index.cshtml
+++ b/src/dotnet/AzureDeploymentWeb/Views/Deployment/Index.cshtml
@@ -74,6 +74,20 @@
             </form>
         </div>
 
+        @if (!string.IsNullOrEmpty(Model.DeploymentStatus) && Model.DeploymentStatus == "queued")
+        {
+            <div class="alert alert-warning mt-4" id="deploymentConfirmation">
+                <h4>🚀 Deployment Queued!</h4>
+                <p>Your deployment has been queued and will start shortly.</p>
+                <p><strong>Resource Group:</strong> @Model.ResourceGroup</p>
+                <p><strong>Deployment Name:</strong> @Model.DeploymentName</p>
+                @if (!string.IsNullOrEmpty(Model.DeploymentMessage))
+                {
+                    <p>@Model.DeploymentMessage</p>
+                }
+            </div>
+        }
+
         @if (!string.IsNullOrEmpty(Model.DeploymentStatus))
         {
             <div class="status-@Model.DeploymentStatus" id="deploymentStatus">

--- a/src/dotnet/AzureDeploymentWeb/appsettings.example.json
+++ b/src/dotnet/AzureDeploymentWeb/appsettings.example.json
@@ -6,10 +6,6 @@
     "ClientSecret": "your-client-secret-here",
     "CallbackPath": "/signin-oidc"
   },
-  "Azure": {
-    "SubscriptionId": "your-subscription-id-here",
-    "ResourceGroup": "your-resource-group-here"
-  },
   "AzureSignalR": {
     "ConnectionString": ""
   },

--- a/src/dotnet/AzureDeploymentWeb/appsettings.json
+++ b/src/dotnet/AzureDeploymentWeb/appsettings.json
@@ -6,10 +6,6 @@
     "ClientSecret": "",
     "CallbackPath": "/signin-oidc"
   },
-  "Azure": {
-    "SubscriptionId": "c5d4a6e8-69bf-4148-be25-cb362f83c370",
-    "ResourceGroup": "RG-WEB-DEPLOY"
-  },
   "Cache": {
     "Redis": {
       "ConnectionString": ""


### PR DESCRIPTION
This pull request introduces a new feature to display a deployment status message in the UI and removes unused Azure configuration settings from the application settings files.

### UI Enhancements:
* [`src/dotnet/AzureDeploymentWeb/Views/Deployment/Index.cshtml`](diffhunk://#diff-7233c4af26473a50a10e995e84fd4f5f0557d59dea328615e56a6ff9c88937dcR77-R90): Added a new alert to display a "Deployment Queued" message when the deployment status is "queued," along with details like resource group, deployment name, and an optional message.

### Configuration Cleanup:
* [`src/dotnet/AzureDeploymentWeb/appsettings.example.json`](diffhunk://#diff-b1aaa3b6a8657aeb556a551c63e8d8a316d4a2970e1f3592903c1c1eb597ee16L9-L12): Removed unused Azure configuration keys (`SubscriptionId` and `ResourceGroup`) from the example app settings file.
* [`src/dotnet/AzureDeploymentWeb/appsettings.json`](diffhunk://#diff-d82fdf4966f8bfbe0c9e3dbaee933fd7f9daaab475d364eb22e5233431e31361L9-L12): Removed hardcoded Azure configuration values (`SubscriptionId` and `ResourceGroup`) from the main app settings file.